### PR TITLE
[jira] BUY-505: Add unit tests for checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 pnpm-lock.yaml
 yarn.lock
 coverage
+.tmp-tests

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint src --ext ts,tsx --max-warnings=0"
+    "lint": "eslint src --ext ts,tsx --max-warnings=0",
+    "test": "npm run test:unit",
+    "test:unit": "node --test tests/unit/**/*.test.cjs"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/tests/unit/app.test.cjs
+++ b/tests/unit/app.test.cjs
@@ -1,0 +1,26 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const fs = require("node:fs")
+const path = require("node:path")
+
+const appFilePath = path.resolve(__dirname, "../../src/pages/app.tsx")
+const appSource = fs.readFileSync(appFilePath, "utf8")
+
+test("includes checkout page headline and subtitle copy", () => {
+  assert.match(appSource, /<h1>Checkout Agent Sandbox<\/h1>/)
+  assert.match(
+    appSource,
+    /Minimal React \+ Vite app for experimenting with agentic workflows\./
+  )
+})
+
+test("includes the expected checkout status and details section headings", () => {
+  assert.match(appSource, /<h2>Current status<\/h2>/)
+  assert.match(appSource, /<h2>Technical details<\/h2>/)
+})
+
+test("includes the expected technical detail list entries", () => {
+  assert.match(appSource, /<li>React 18 \+ TypeScript<\/li>/)
+  assert.match(appSource, /<li>Vite as the build tool<\/li>/)
+  assert.match(appSource, /<li>Ready to move into a separate repository<\/li>/)
+})


### PR DESCRIPTION
## Jira Task
- **Key:** BUY-505
- **Title:** Add tests
- **Description / Acceptance criteria:**
  - Add unit tests for checkout

## What Changed
- Added a test entrypoint in `package.json`:
  - `test`
  - `test:unit`
- Added dependency-free unit tests in `tests/unit/app.test.cjs` for the checkout page (`App`) covering:
  - Headline and subtitle content
  - Section headings
  - Technical detail list entries
- Added `.tmp-tests` to `.gitignore` to avoid committing temporary test artifacts when local test tooling writes them.

## Validation
- Ran `npm test` successfully (3 tests passing).

## Notes
- No Jira base URL was provided in this workflow context, so a direct issue link is not included.




> Generated by [Jira → Pull Request (Tech Debt Agent)](https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/22960543086) · [◷](https://github.com/search?q=repo%3Anickerm3n%2FStorio-agent-checkout+%22gh-aw-workflow-id%3A+jira-to-pr%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 2 domains</summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `ab.chatgpt.com`
> - `registry.npmjs.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "ab.chatgpt.com"
>     - "registry.npmjs.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Jira → Pull Request (Tech Debt Agent), engine: codex, id: 22960543086, workflow_id: jira-to-pr, run: https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/22960543086 -->

<!-- gh-aw-workflow-id: jira-to-pr -->