### PR TITLE
[jira] DEV-1: Add tests for checkout flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint src --ext ts,tsx --max-warnings=0"
+    "lint": "eslint src --ext ts,tsx --max-warnings=0",
+    "test": "node --test tests/**/*.test.mjs"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/src/pages/app.tsx
+++ b/src/pages/app.tsx
@@ -1,31 +1,34 @@
 import React from "react"
+import { checkoutPageContent, getCheckoutCard } from "./checkout-content.mjs"
 
 export function App() {
+  const statusCard = getCheckoutCard("Current status")
+  const detailsCard = getCheckoutCard("Technical details")
+
+  if (!statusCard || !detailsCard || !detailsCard.items) {
+    throw new Error("Checkout page content is missing required cards")
+  }
+
   return (
     <div className="page">
       <header className="page-header">
-        <span className="badge">PoC</span>
-        <h1>Checkout Agent Sandbox</h1>
-        <p className="subtitle">
-          Minimal React + Vite app for experimenting with agentic workflows.
-        </p>
+        <span className="badge">{checkoutPageContent.badge}</span>
+        <h1>{checkoutPageContent.title}</h1>
+        <p className="subtitle">{checkoutPageContent.subtitle}</p>
       </header>
 
       <main className="page-main">
         <section className="card">
-          <h2>Current status</h2>
-          <p>
-            Single-page view without routing. Next steps: plug in agent actions
-            such as reading Jira issues and generating pull requests.
-          </p>
+          <h2>{statusCard.heading}</h2>
+          <p>{statusCard.description}</p>
         </section>
 
         <section className="card">
-          <h2>Technical details</h2>
+          <h2>{detailsCard.heading}</h2>
           <ul className="list">
-            <li>React 18 + TypeScript</li>
-            <li>Vite as the build tool</li>
-            <li>Ready to move into a separate repository</li>
+            {detailsCard.items.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
           </ul>
         </section>
       </main>

--- a/src/pages/checkout-content.mjs
+++ b/src/pages/checkout-content.mjs
@@ -1,0 +1,25 @@
+export const checkoutPageContent = {
+  badge: "PoC",
+  title: "Checkout Agent Sandbox",
+  subtitle:
+    "Minimal React + Vite app for experimenting with agentic workflows.",
+  cards: [
+    {
+      heading: "Current status",
+      description:
+        "Single-page view without routing. Next steps: plug in agent actions such as reading Jira issues and generating pull requests."
+    },
+    {
+      heading: "Technical details",
+      items: [
+        "React 18 + TypeScript",
+        "Vite as the build tool",
+        "Ready to move into a separate repository"
+      ]
+    }
+  ]
+}
+
+export function getCheckoutCard(heading) {
+  return checkoutPageContent.cards.find((card) => card.heading === heading)
+}

--- a/tests/checkout.test.mjs
+++ b/tests/checkout.test.mjs
@@ -1,0 +1,37 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import {
+  checkoutPageContent,
+  getCheckoutCard
+} from "../src/pages/checkout-content.mjs"
+
+test("checkout page exposes the expected main heading and subtitle", () => {
+  assert.equal(checkoutPageContent.title, "Checkout Agent Sandbox")
+  assert.match(
+    checkoutPageContent.subtitle,
+    /Minimal React \+ Vite app for experimenting with agentic workflows\./
+  )
+})
+
+test("current status card exists and includes workflow copy", () => {
+  const statusCard = getCheckoutCard("Current status")
+
+  assert.ok(statusCard)
+  assert.equal(statusCard.heading, "Current status")
+  assert.match(statusCard.description, /Single-page view without routing\./)
+})
+
+test("technical details card includes all listed technologies", () => {
+  const detailsCard = getCheckoutCard("Technical details")
+
+  assert.ok(detailsCard)
+  assert.deepEqual(detailsCard.items, [
+    "React 18 + TypeScript",
+    "Vite as the build tool",
+    "Ready to move into a separate repository"
+  ])
+})
+
+test("getCheckoutCard returns undefined for unknown headings", () => {
+  assert.equal(getCheckoutCard("Not a real card"), undefined)
+})


### PR DESCRIPTION
## Jira Task
- **Key:** DEV-1
- **Title:** Add tests

## Description / Acceptance Criteria
### Scope
Add unit tests for the checkout flow to improve code coverage and catch regressions. Tests should cover the main checkout page components, user interactions, and integration with existing services where applicable.

### Acceptance Criteria
- Unit tests are added for the checkout-related code (e.g. checkout page, components, or services).
- Tests use the project's existing test runner and conventions (e.g. Node `node:test`, Vitest, or Jest).
- At least one test file is added or extended (e.g. `tests/checkout.test.mjs` or equivalent).
- A `test` script is present in `package.json` and can be run via `npm test` or equivalent.
- Tests pass locally and are suitable for CI.

## Changes Made
- Added a `test` script in `package.json` using Node's built-in test runner: `node --test tests/**/*.test.mjs`.
- Extracted checkout page content into a dedicated module: `src/pages/checkout-content.mjs`.
- Updated `src/pages/app.tsx` to consume checkout content from the new module.
- Added unit tests in `tests/checkout.test.mjs` covering:
  - Main checkout heading/subtitle content
  - Current status card retrieval and content
  - Technical details card list content
  - Unknown-card behavior for content lookup

## Validation
- Ran `npm test` locally: **4 tests passed**.

## Notes
- No Jira base URL was provided in workflow inputs, so no direct Jira link is included.




> Generated by [Jira → Pull Request (Tech Debt Agent)](https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23000876536) · [◷](https://github.com/search?q=repo%3Anickerm3n%2FStorio-agent-checkout+%22gh-aw-workflow-id%3A+jira-to-pr%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 2 domains</summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `ab.chatgpt.com`
> - `registry.npmjs.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "ab.chatgpt.com"
>     - "registry.npmjs.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Jira → Pull Request (Tech Debt Agent), engine: codex, id: 23000876536, workflow_id: jira-to-pr, run: https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23000876536 -->

<!-- gh-aw-workflow-id: jira-to-pr -->