### PR TITLE
[jira] DEV-1: Add tests for checkout page

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint src --ext ts,tsx --max-warnings=0"
+    "lint": "eslint src --ext ts,tsx --max-warnings=0",
+    "test": "node --test tests/**/*.test.mjs",
+    "test:watch": "node --test --watch tests/**/*.test.mjs"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/tests/checkout.test.mjs
+++ b/tests/checkout.test.mjs
@@ -1,0 +1,26 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import path from "node:path"
+
+const appFilePath = path.resolve(process.cwd(), "src/pages/app.tsx")
+const appSource = fs.readFileSync(appFilePath, "utf8")
+
+test("checkout page renders expected top-level sections", () => {
+  assert.match(appSource, /<header className="page-header">/)
+  assert.match(appSource, /<main className="page-main">/)
+  const cardSections = appSource.match(/<section className="card">/g) ?? []
+  assert.ok(cardSections.length >= 2)
+})
+
+test("checkout page includes current status and technical detail content", () => {
+  assert.match(appSource, /<h2>Current status<\/h2>/)
+  assert.match(appSource, /<h2>Technical details<\/h2>/)
+  assert.match(appSource, /Next steps: plug in agent actions/)
+})
+
+test("technical details list keeps expected baseline items", () => {
+  assert.match(appSource, /<li>React 18 \+ TypeScript<\/li>/)
+  assert.match(appSource, /<li>Vite as the build tool<\/li>/)
+  assert.match(appSource, /<li>Ready to move into a separate repository<\/li>/)
+})


### PR DESCRIPTION
## Jira Task
- Key: DEV-1
- Title: Add tests

## Description / Acceptance Criteria
h2. Scope

Add unit tests for the checkout flow to improve code coverage and catch regressions. Tests should cover the main checkout page components, user interactions, and integration with existing services where applicable. Do not add new functionallyty just create base tests for existing page

h2. Acceptance Criteria

* Unit tests are added for the checkout-related code (e.g. checkout page, components, or services).
* Tests use the project's existing test runner and conventions (e.g. Node `node:test`, Vitest, or Jest).
* At least one test file is added or extended (e.g. `tests/checkout.test.mjs` or equivalent).
* A `test` script is present in `package.json` and can be run via `npm test` or equivalent.
* Tests pass locally and are suitable for CI.

## Changes Made
- Added a `test` script to `package.json` using Node's built-in test runner.
- Added `test:watch` script for local development parity.
- Added `tests/checkout.test.mjs` with baseline unit tests for the checkout page component source, covering:
  - top-level page structure (header/main/cards)
  - current status and technical details sections
  - expected technical details list items

## Validation
- Ran `npm test` locally: 3 tests passed.

## Notes
- The current checkout page has static content and no interactive controls or service integration yet, so tests focus on baseline rendering/content regressions for existing code only.




> Generated by [Jira → Pull Request (Tech Debt Agent)](https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23003277042) · [◷](https://github.com/search?q=repo%3Anickerm3n%2FStorio-agent-checkout+%22gh-aw-workflow-id%3A+jira-to-pr%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 2 domains</summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `ab.chatgpt.com`
> - `registry.npmjs.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "ab.chatgpt.com"
>     - "registry.npmjs.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Jira → Pull Request (Tech Debt Agent), engine: codex, id: 23003277042, workflow_id: jira-to-pr, run: https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23003277042 -->

<!-- gh-aw-workflow-id: jira-to-pr -->