### PR TITLE
[jira] DEV-7: Add header to main page

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,0 +1,25 @@
+import React from "react"
+
+const APP_TITLE = String(import.meta.env.VITE_APP_TITLE || "Checkout Agent")
+
+export function AppHeader() {
+  return (
+    <header className="app-header">
+      <span className="app-header__title">{APP_TITLE}</span>
+      <nav aria-label="Main navigation">
+        <ul className="app-header__nav">
+          <li>
+            <a href="#" className="app-header__link">
+              Home
+            </a>
+          </li>
+          <li>
+            <a href="#" className="app-header__link">
+              Settings
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </header>
+  )
+}

--- a/src/pages/app.tsx
+++ b/src/pages/app.tsx
@@ -1,8 +1,10 @@
 import React from "react"
+import { AppHeader } from "../components/AppHeader"
 
 export function App() {
   return (
     <div className="page">
+      <AppHeader />
       <header className="page-header">
         <span className="badge">PoC</span>
         <h1>Checkout Agent Sandbox</h1>

--- a/src/styles.css
+++ b/src/styles.css
@@ -96,3 +96,43 @@ h1 {
     padding-inline: 1.1rem;
   }
 }
+
+/* App header / navigation bar */
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6rem 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.app-header__title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #f9fafb;
+  letter-spacing: -0.01em;
+}
+
+.app-header__nav {
+  display: flex;
+  gap: 1.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.app-header__link {
+  color: #9ca3af;
+  text-decoration: none;
+  font-size: 0.875rem;
+}
+
+.app-header__link:hover {
+  color: #f9fafb;
+}
+
+@media (max-width: 640px) {
+  .app-header__nav {
+    gap: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary

Implements [DEV-7] — Add a header component to the main page of the frontend app.

- **New file** `src/components/AppHeader.tsx` — `AppHeader` component that displays the application name (from `VITE_APP_TITLE` env variable, falling back to `"Checkout Agent"`) and two placeholder nav links: **Home** and **Settings** (both `href="#"` as per spec).
- **Modified** `src/styles.css` — added `.app-header`, `.app-header__title`, `.app-header__nav`, `.app-header__link` styles consistent with existing dark theme (colors, typography, spacing). Responsive at `≤640px`.
- **Modified** `src/pages/app.tsx` — imported and mounted `(AppHeader /)` as the first element inside `.page`, above the existing hero header. No existing logic changed.

## Acceptance criteria

| Criterion | Status |
|-----------|--------|
| Header component exists and renders at top of main page | ✅ `AppHeader` mounted first in `App` |
| Displays application name (or configurable title) | ✅ `VITE_APP_TITLE` env var with fallback |
| At least one nav link present | ✅ Home + Settings links |
| Layout responsive, no breakage on narrow viewports | ✅ `@media (max-width: 640px)` rule |
| Styling consistent with existing app | ✅ Same dark palette and CSS conventions |
| No changes to existing app logic | ✅ Only new component + minimal wiring |

## Pipeline state

- **Classify:** Simple feature / UI — clear scope and acceptance criteria.
- **Development:** 3 files touched; new component + CSS + one-line mount.
- **Quality:** Lint — no ESLint config present in repo (pre-existing); Tests — no test scripts; Build — **PASS** (Vite, 32 modules, 724ms).

## Test plan

- [ ] `npm run build` — should pass (verified locally ✅)
- [ ] `npm run dev` — navigate to `(localhost/redacted) confirm header renders at top with app name and "Home" / "Settings" links
- [ ] Resize to mobile width (< 640px); confirm header does not overflow




> Generated by [Jira → Pull Request (Orchestrator + Development)](https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23116277070) · [◷](https://github.com/search?q=repo%3Anickerm3n%2FStorio-agent-checkout+%22gh-aw-workflow-id%3A+jira-to-pr%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Jira → Pull Request (Orchestrator + Development), engine: claude, id: 23116277070, workflow_id: jira-to-pr, run: https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23116277070 -->

<!-- gh-aw-workflow-id: jira-to-pr -->