### PR TITLE
[jira] DEV-7: Add header to main page

### DIFF
--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -1,0 +1,26 @@
+import React from "react"
+
+const defaultAppName = "Checkout Agent Sandbox"
+
+export function AppHeader() {
+  const appName = import.meta.env.VITE_APP_NAME || defaultAppName
+
+  return (
+    <header className="app-header" aria-label="Main navigation">
+      <a className="app-name" href="#">
+        {appName}
+      </a>
+
+      <nav>
+        <ul className="app-nav">
+          <li>
+            <a href="#">Home</a>
+          </li>
+          <li>
+            <a href="#">Settings</a>
+          </li>
+        </ul>
+      </nav>
+    </header>
+  )
+}

--- a/src/pages/app.tsx
+++ b/src/pages/app.tsx
@@ -1,8 +1,11 @@
 import React from "react"
+import { AppHeader } from "../components/app-header"
 
 export function App() {
   return (
     <div className="page">
+      <AppHeader />
+
       <header className="page-header">
         <span className="badge">PoC</span>
         <h1>Checkout Agent Sandbox</h1>

--- a/src/styles.css
+++ b/src/styles.css
@@ -19,6 +19,42 @@ body {
   margin: 0 auto;
 }
 
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.app-name {
+  color: #f9fafb;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+}
+
+.app-nav {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.app-nav a {
+  color: #93c5fd;
+  text-decoration: none;
+  font-size: 0.95rem;
+}
+
+.app-nav a:hover {
+  color: #bfdbfe;
+}
+
 .page-header {
   display: flex;
   flex-direction: column;
@@ -94,5 +130,10 @@ h1 {
 @media (max-width: 640px) {
   .page {
     padding-inline: 1.1rem;
+  }
+
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }


### PR DESCRIPTION
## Jira Task
- **Key:** DEV-7
- **Title:** Add header to main page

### Description / Scope / Acceptance Criteria
- Add a header to the main frontend page with app name and minimal navigation (Home, Settings).
- Reuse existing styling (project CSS).
- Do not add new routes or pages.
- Add a header component and render it at the top of the main page.
- Display app name (or configurable title from env/config).
- Include placeholder nav links.
- Keep layout responsive and avoid unrelated logic/component changes.

## Changes Implemented
- Added new reusable header component:
  - `src/components/app-header.tsx`
  - Renders app name using `import.meta.env.VITE_APP_NAME` fallbacking to `Checkout Agent Sandbox`.
  - Includes placeholder navigation links: `Home` and `Settings` (`href="#"`).
- Wired header into the top of the main page:
  - `src/pages/app.tsx`
  - Imported and rendered `(AppHeader /)` before existing page content.
- Added matching styles in existing stylesheet:
  - `src/styles.css`
  - Added `.app-header`, `.app-name`, `.app-nav` styles and mobile behavior at `max-width: 640px`.

## Pipeline State
- Classify: `Simple feature / UI` (clear scope and acceptance criteria).
- Plan: Skipped (not needed; scope clear).
- Development: Complete.
- Quality:
  - `npm run lint`: failed to execute (`eslint: not found`) in this runner.
  - `npm run build`: failed to execute (`vite: not found`) in this runner.
  - `npm run test`: script not defined in `package.json`.
  - Note: local dependency installation/check execution appears restricted in this environment.
- PR: Created.

## Jira MCP Limitation
The required Jira MCP tools (`add_comment`, `transition_issue`) were not available in this runtime, so phase comments/transition could not be performed from this run.




> Generated by [Jira → Pull Request (Orchestrator + Development)](https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23116539242) · [◷](https://github.com/search?q=repo%3Anickerm3n%2FStorio-agent-checkout+%22gh-aw-workflow-id%3A+jira-to-pr%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 2 domains</summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `ab.chatgpt.com`
> - `registry.npmjs.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "ab.chatgpt.com"
>     - "registry.npmjs.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Jira → Pull Request (Orchestrator + Development), engine: codex, id: 23116539242, workflow_id: jira-to-pr, run: https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23116539242 -->

<!-- gh-aw-workflow-id: jira-to-pr -->