### PR TITLE
[jira] DEV-7: Add header to main page

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,15 @@
+import React from "react"
+
+const APP_TITLE = (import.meta.env.VITE_APP_TITLE as string | undefined) ?? "Storio Agent"
+
+export function Header() {
+  return (
+    <header className="site-header">
+      <span className="site-header__title">{APP_TITLE}</span>
+      <nav className="site-header__nav" aria-label="Main navigation">
+        <a href="#" className="site-header__link">Home</a>
+        <a href="#" className="site-header__link">Settings</a>
+      </nav>
+    </header>
+  )
+}

--- a/src/pages/app.tsx
+++ b/src/pages/app.tsx
@@ -1,8 +1,11 @@
 import React from "react"
+import { Header } from "../components/Header"
 
 export function App() {
   return (
-    <div className="page">
+    <>
+      <Header />
+      <div className="page">
       <header className="page-header">
         <span className="badge">PoC</span>
         <h1>Checkout Agent Sandbox</h1>
@@ -29,6 +32,7 @@ export function App() {
           </ul>
         </section>
       </main>
-    </div>
+      </div>
+    </>
   )
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -91,8 +91,48 @@ h1 {
   color: #60a5fa;
 }
 
+/* ── Site-wide navigation header ── */
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.8rem 1.5rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+  background: rgba(5, 7, 22, 0.96);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.site-header__title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: -0.01em;
+  color: #f9fafb;
+}
+
+.site-header__nav {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.site-header__link {
+  color: #9ca3af;
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: color 0.15s;
+}
+
+.site-header__link:hover {
+  color: #60a5fa;
+}
+
 @media (max-width: 640px) {
   .page {
     padding-inline: 1.1rem;
+  }
+
+  .site-header {
+    padding: 0.65rem 1.1rem;
   }
 }


### PR DESCRIPTION
## Summary

Implements [DEV-7: Add header to main page]((jira.example.com/redacted)

- Adds `src/components/Header.tsx` — a new `Header` component that displays the app title (configurable via `VITE_APP_TITLE` env var, defaults to `"Storio Agent"`) and two placeholder nav links (`Home`, `Settings`).
- Updates `src/pages/app.tsx` — mounts `(Header /)` at the top of the page (before the existing `.page` container).
- Updates `src/styles.css` — adds `.site-header`, `.site-header__title`, `.site-header__nav`, and `.site-header__link` styles consistent with the existing dark-theme CSS palette; responsive breakpoint at 640 px.

## Changes

| File | Change |
|---|---|
| `src/components/Header.tsx` | **New** — Header component |
| `src/pages/app.tsx` | Mount `(Header /)` at top; wrap in React fragment |
| `src/styles.css` | Add site-header CSS rules |

## Acceptance criteria

- [x] Header component exists and is rendered at the top of the main page
- [x] Displays app name (`VITE_APP_TITLE` env or default `"Storio Agent"`)
- [x] Nav links present: **Home** and **Settings** (placeholder `#` hrefs)
- [x] Responsive — padding reduces at ≤ 640 px; uses `flex` so it stacks gracefully
- [x] Styling consistent with existing dark-theme CSS (same colour tokens: `#f9fafb`, `#9ca3af`, `#60a5fa`)
- [x] No changes to existing app logic — only new component + layout wiring

## Pipeline state

| Phase | Result |
|---|---|
| Classify | Simple feature / UI — clear scope and AC |
| Plan | Skipped (scope clear) |
| Development | `Header.tsx` created; `app.tsx` + `styles.css` updated |
| Quality | Lint: no config (pre-existing repo issue, unrelated to this PR). Build: **pass** (`vite build` ✓). |
| PR | This PR |

> **Note:** Jira MCP (`add_comment`, `transition_issue`) was not available in the current tool environment. Jira comments and the Code Review transition should be handled by the `notify-jira-on-pr` workflow or manually.




> Generated by [Jira → Pull Request (Orchestrator + Development)](https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23116807378) · [◷](https://github.com/search?q=repo%3Anickerm3n%2FStorio-agent-checkout+%22gh-aw-workflow-id%3A+jira-to-pr%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Jira → Pull Request (Orchestrator + Development), engine: claude, id: 23116807378, workflow_id: jira-to-pr, run: https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23116807378 -->

<!-- gh-aw-workflow-id: jira-to-pr -->