### PR TITLE
[jira] DEV-7: Add header to main page

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,0 +1,21 @@
+import React from "react"
+
+const APP_TITLE = "Checkout Agent"
+
+export function AppHeader() {
+  return (
+    <nav className="app-header" data-test="DEV-7-header">
+      <div className="app-header-inner">
+        <span className="app-header-title">{APP_TITLE}</span>
+        <ul className="app-header-nav">
+          <li>
+            <a href="#">Home</a>
+          </li>
+          <li>
+            <a href="#">Settings</a>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  )
+}

--- a/src/pages/app.tsx
+++ b/src/pages/app.tsx
@@ -1,8 +1,11 @@
 import React from "react"
+import { AppHeader } from "../components/AppHeader"
 
 export function App() {
   return (
-    <div className="page">
+    <>
+      <AppHeader />
+      <div className="page">
       <header className="page-header">
         <span className="badge">PoC</span>
         <h1>Checkout Agent Sandbox</h1>
@@ -30,5 +33,6 @@ export function App() {
         </section>
       </main>
     </div>
+    </>
   )
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -91,8 +91,56 @@ h1 {
   color: #60a5fa;
 }
 
+.app-header {
+  background: rgba(5, 7, 22, 0.92);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+  backdrop-filter: blur(8px);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.app-header-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0.75rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.app-header-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #f9fafb;
+  letter-spacing: -0.01em;
+}
+
+.app-header-nav {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 1.5rem;
+}
+
+.app-header-nav a {
+  color: #9ca3af;
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: color 0.15s;
+}
+
+.app-header-nav a:hover {
+  color: #f9fafb;
+}
+
 @media (max-width: 640px) {
   .page {
+    padding-inline: 1.1rem;
+  }
+
+  .app-header-inner {
     padding-inline: 1.1rem;
   }
 }


### PR DESCRIPTION
## Summary

Implements [DEV-7](https://nickerm3n.atlassian.net/browse/DEV-7) — adds a navigation header to the main page of the frontend app.

- **New** `src/components/AppHeader.tsx` — `AppHeader` functional component with app title ("Checkout Agent") and placeholder nav links (Home, Settings); includes `data-test="DEV-7-header"` for selector targeting.
- **Modified** `src/styles.css` — added `.app-header` styles: sticky top bar, consistent dark theme (`#050716` bg, `#9ca3af`/`#f9fafb` text), responsive padding on narrow viewports (`max-width: 640px`).
- **Modified** `src/pages/app.tsx` — imported `AppHeader` and rendered it at the top of the page (above the existing `.page` div) via a React fragment; no other changes to existing content.

## Acceptance criteria coverage

| Criterion | Status |
|---|---|
| Header component rendered at top of main page | ✅ `(AppHeader /)` is the first element in `App` |
| Displays application name | ✅ "Checkout Agent" |
| At least one nav link (placeholder ok) | ✅ Home + Settings, both `href="#"` |
| Responsive layout | ✅ `padding-inline` adjusted at `max-width: 640px` |
| Consistent with existing styling | ✅ Same dark-theme palette and font stack |
| No changes to existing app logic | ✅ Only new component + import/mount in `App` |

## Pipeline state

| Phase | Result |
|---|---|
| Classify | Simple feature / UI |
| Plan | Skipped (clear scope + AC) |
| Development | `AppHeader` component + CSS + mount in `app.tsx` |
| Quality | TypeScript: pass · Build: pass · Lint: no config (pre-existing) |
| Visual | Playwright blocked by sandbox network isolation; verify locally via `npm run dev` → `[data-test="DEV-7-header"]` |

## Test plan

- [ ] Run `npm run dev` locally; confirm sticky nav bar appears at top with "Checkout Agent" title and Home / Settings links.
- [ ] Resize to narrow viewport (< 640 px); confirm layout does not break.
- [ ] Confirm existing page content (badge, h1, cards) is unchanged below the header.




> Generated by [Jira → Pull Request (Orchestrator + Development)](https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23191134127) · [◷](https://github.com/search?q=repo%3Anickerm3n%2FStorio-agent-checkout+%22gh-aw-workflow-id%3A+jira-to-pr%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Jira → Pull Request (Orchestrator + Development), engine: claude, id: 23191134127, workflow_id: jira-to-pr, run: https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23191134127 -->

<!-- gh-aw-workflow-id: jira-to-pr -->