### PR TITLE
[deps] Daily dependency update 2026-03-20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1699,9 +1699,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
## Summary

- Patches **high-severity** prototype pollution vulnerability in `flatted` (GHSA-rf6f-7fwh-wjgh) by upgrading `flatted` 3.4.1 → 3.4.2 via `npm audit fix`
- Only `package-lock.json` is changed; no application source code modified
- See the dependency report issue for full audit details

## Changes

| Package | Before | After | Severity |
|---------|--------|-------|----------|
| flatted | 3.4.1 | 3.4.2 | high → resolved |

## What was skipped

- `esbuild`/`vite` moderate CVEs: fix requires vite@8 (major breaking change) — not auto-applied
- `react`/`react-dom` v19: major version bump — not auto-applied

## Test plan

- [ ] Verify `npm audit` shows 0 high/critical after merge
- [ ] Confirm `npm run build` and `npm run dev` still work as expected




> Generated by [Dependency Report (PoC)](https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23336321271) · [◷](https://github.com/search?q=repo%3Anickerm3n%2FStorio-agent-checkout+%22gh-aw-workflow-id%3A+dependency-report%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Dependency Report (PoC), engine: claude, id: 23336321271, workflow_id: dependency-report, run: https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23336321271 -->

<!-- gh-aw-workflow-id: dependency-report -->