### PR TITLE
[jira] DEV-9: Add AppHeader component with app name and nav links

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,0 +1,15 @@
+import React from "react"
+
+const APP_TITLE = import.meta.env.VITE_APP_TITLE ?? "Storio"
+
+export function AppHeader() {
+  return (
+    <header className="app-header" data-test="DEV-9-header">
+      <span className="app-header__title">{APP_TITLE}</span>
+      <nav className="app-header__nav" aria-label="Main navigation">
+        <a href="#" className="app-header__nav-link">Home</a>
+        <a href="#" className="app-header__nav-link">Settings</a>
+      </nav>
+    </header>
+  )
+}

--- a/src/pages/app.tsx
+++ b/src/pages/app.tsx
@@ -1,7 +1,10 @@
 import React from "react"
+import { AppHeader } from "../components/AppHeader"
 
 export function App() {
   return (
+    <>
+    <AppHeader />
     <div className="page">
       <header className="page-header">
         <span className="badge">PoC</span>
@@ -30,5 +33,6 @@ export function App() {
         </section>
       </main>
     </div>
+    </>
   )
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,3 +1,51 @@
+/* ── App header ────────────────────────────────────── */
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.5rem;
+  background: rgba(5, 7, 22, 0.85);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.app-header__title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: #f9fafb;
+}
+
+.app-header__nav {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.app-header__nav-link {
+  font-size: 0.9rem;
+  color: #9ca3af;
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.app-header__nav-link:hover {
+  color: #f9fafb;
+}
+
+@media (max-width: 640px) {
+  .app-header {
+    padding-inline: 1.1rem;
+  }
+
+  .app-header__nav {
+    gap: 1rem;
+  }
+}
+
+/* ── Root ────────────────────────────────────────────── */
 :root {
   color-scheme: light dark;
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;


### PR DESCRIPTION
## Summary

Implements [DEV-9] — adds a persistent navigation header to the main page of the Storio frontend app.

## Changes

| File | Change |
|------|--------|
| `src/components/AppHeader.tsx` | **New** — `AppHeader` component with app title and Home/Settings nav links |
| `src/pages/app.tsx` | Mount `(AppHeader /)` at the top of the page (fragment wrapper added) |
| `src/styles.css` | New `.app-header` CSS block — sticky, blur backdrop, responsive |

## Acceptance Criteria ✅

- ✅ Header component (`AppHeader`) exists and renders at the top of the main page
- ✅ Displays app name (`VITE_APP_TITLE` env var with `"Storio"` fallback)
- ✅ Two nav links present: **Home** and **Settings** (placeholder `#` hrefs)
- ✅ Responsive — collapses gracefully on narrow viewports (`≤640px`)
- ✅ Styling consistent with existing dark-theme CSS (no Tailwind added)
- ✅ No changes to existing app logic — only new component + mount wiring

## Pipeline state

| Phase | Result |
|-------|--------|
| Classify | Simple feature / UI — clear scope & AC |
| Plan | Skipped (scope clear) |
| Development | `AppHeader.tsx` created, mounted in `App`, styles added |
| Quality | Lint: no config (pre-existing) · Build: ✅ pass |
| Visual | `data-test="DEV-9-header"` selector available for Playwright checks |

> **Note:** Jira MCP comments could not be posted — the `DEV-9` issue returned a permissions error. This PR description serves as the pipeline record.




> Generated by [Jira → Pull Request (Orchestrator + Development)](https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23347534586) · [◷](https://github.com/search?q=repo%3Anickerm3n%2FStorio-agent-checkout+%22gh-aw-workflow-id%3A+jira-to-pr%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Jira → Pull Request (Orchestrator + Development), engine: copilot, id: 23347534586, workflow_id: jira-to-pr, run: https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23347534586 -->

<!-- gh-aw-workflow-id: jira-to-pr -->