### PR TITLE
[deps] Daily dependency update 2026-03-21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1699,9 +1699,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
Automated daily dependency update for 2026-03-21.

## Changes

- **flatted** 3.4.1 → 3.4.2 (`package-lock.json` only)
  - Fixes high-severity prototype pollution vulnerability [GHSA-rf6f-7fwh-wjgh](https://github.com/advisories/GHSA-rf6f-7fwh-wjgh)
  - Applied via `npm audit fix` (patch update, no breaking changes)

## Skipped

- **react / react-dom** v19 — major version bump, skipped per policy
- **esbuild / vite** fix — requires vite@8 (major), skipped per policy

See the dependency report issue #29 for the full audit.




> Generated by [Dependency Report (PoC)](https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23376381024) · [◷](https://github.com/search?q=repo%3Anickerm3n%2FStorio-agent-checkout+%22gh-aw-workflow-id%3A+dependency-report%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Dependency Report (PoC), engine: claude, id: 23376381024, workflow_id: dependency-report, run: https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23376381024 -->

<!-- gh-aw-workflow-id: dependency-report -->