### PR TITLE
[deps] Daily dependency update 2026-03-22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1699,9 +1699,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
## Summary

- Bumps `flatted` from **3.4.1 → 3.4.2** to fix a **high-severity** Prototype Pollution vulnerability ([GHSA-rf6f-7fwh-wjgh](https://github.com/advisories/GHSA-rf6f-7fwh-wjgh))
- Only `package-lock.json` was modified (no source code changes)
- Applied via `npm audit fix` (non-breaking, patch update)

## Skipped

- `esbuild`/`vite` moderate vulnerabilities: fix requires `vite@8.0.1` (semver-major), skipped per policy
- `react`/`react-dom` v19: major version bump, skipped per policy

## Test plan

- [ ] Verify `npm ci` completes without errors
- [ ] Run `npm run build` to confirm build still works
- [ ] Run `npm audit` — should show 2 moderate remaining (esbuild/vite, dev-only)

See the dependency report issue for full details.

🤖 Generated with [Claude Code]((claude.com/redacted)




> Generated by [Dependency Report (PoC)](https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23399813601) · [◷](https://github.com/search?q=repo%3Anickerm3n%2FStorio-agent-checkout+%22gh-aw-workflow-id%3A+dependency-report%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Dependency Report (PoC), engine: claude, id: 23399813601, workflow_id: dependency-report, run: https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23399813601 -->

<!-- gh-aw-workflow-id: dependency-report -->