### PR TITLE
[deps] Daily dependency update 2026-03-24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1699,9 +1699,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
## Summary

- Bumped `flatted` from **3.4.1 → 3.4.2** in `package-lock.json` to fix a **high-severity** prototype pollution vulnerability ([GHSA-rf6f-7fwh-wjgh](https://github.com/advisories/GHSA-rf6f-7fwh-wjgh)).
- No `package.json` changes — only the lockfile was updated.
- 2 moderate vulnerabilities remain (`esbuild`/`vite`) that require a major version bump (`vite@8`) and were intentionally skipped.

Linked report issue: #37

## Test plan

- [ ] Verify `npm install` succeeds with updated lockfile
- [ ] Run `npm audit` and confirm `flatted` is no longer flagged
- [ ] Run `npm run build` to confirm no breakage




> Generated by [Dependency Report (PoC)](https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23481940206) · [◷](https://github.com/search?q=repo%3Anickerm3n%2FStorio-agent-checkout+%22gh-aw-workflow-id%3A+dependency-report%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Dependency Report (PoC), engine: claude, id: 23481940206, workflow_id: dependency-report, run: https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23481940206 -->

<!-- gh-aw-workflow-id: dependency-report -->