### PR TITLE
[deps] Daily dependency update 2026-03-25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1699,9 +1699,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
Bumps `flatted` from 3.4.1 → 3.4.2 in `package-lock.json` to resolve a **high-severity prototype pollution vulnerability** ([GHSA-rf6f-7fwh-wjgh](https://github.com/advisories/GHSA-rf6f-7fwh-wjgh), CWE-1321).

This is a transitive dev dependency (used by eslint's caching layer). The fix is a non-breaking patch update applied via `npm audit fix`.

See the full dependency report issue #39 for details on remaining vulnerabilities and all outdated packages.




> Generated by [Dependency Report (PoC)](https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23533616517) · [◷](https://github.com/search?q=repo%3Anickerm3n%2FStorio-agent-checkout+%22gh-aw-workflow-id%3A+dependency-report%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Dependency Report (PoC), engine: claude, id: 23533616517, workflow_id: dependency-report, run: https://github.com/nickerm3n/Storio-agent-checkout/actions/runs/23533616517 -->

<!-- gh-aw-workflow-id: dependency-report -->